### PR TITLE
[fix] NSNotFound 逻辑判断回滚到错误版本

### DIFF
--- a/QMUIKit/UIKitExtensions/UITableView+QMUI.m
+++ b/QMUIKit/UIKitExtensions/UITableView+QMUI.m
@@ -286,9 +286,9 @@ static char kAssociatedObjectKey_initialContentInset;
     NSInteger numberOfSections = [self numberOfSections];
     if (indexPath.section >= numberOfSections) {
         isIndexPathLegal = NO;
-    } else {
+    } else if (indexPath.row != NSNotFound) {
         NSInteger rows = [self numberOfRowsInSection:indexPath.section];
-        isIndexPathLegal = rows > 0 ? indexPath.row < rows : indexPath.row == NSNotFound;
+        isIndexPathLegal = indexPath.row < rows;
     }
     if (!isIndexPathLegal) {
         QMUILogWarn(@"UITableView (QMUI)", @"%@ - target indexPath : %@ ，不合法的indexPath。\n%@", self, indexPath, [NSThread callStackSymbols]);


### PR DESCRIPTION
当indexPath.row == NSNotFound时，无需再取numberOfRowsInSection做判断。