### PR TITLE
fix: request image for asset memory leaks

### DIFF
--- a/QMUIKit/QMUIComponents/AssetLibrary/QMUIAsset.m
+++ b/QMUIKit/QMUIComponents/AssetLibrary/QMUIAsset.m
@@ -124,9 +124,9 @@ static NSString * const kAssetInfoSize = @"size";
     PHImageRequestOptions *imageRequestOptions = [[PHImageRequestOptions alloc] init];
     imageRequestOptions.networkAccessAllowed = YES; // 允许访问网络
     imageRequestOptions.progressHandler = phProgressHandler;
-    return [[[QMUIAssetsManager sharedInstance] phCachingImageManager] requestImageForAsset:_phAsset targetSize:PHImageManagerMaximumSize contentMode:PHImageContentModeDefault options:imageRequestOptions resultHandler:^(UIImage *result, NSDictionary *info) {
+    return [[[QMUIAssetsManager sharedInstance] phCachingImageManager] requestImageDataForAsset:_phAsset options:imageRequestOptions resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, UIImageOrientation orientation, NSDictionary * _Nullable info) {
         if (completion) {
-            completion(result, info);
+            completion([UIImage imageWithData:imageData], info);
         }
     }];
 }


### PR DESCRIPTION
fix the issue [https://github.com/Tencent/QMUI_iOS/issues/376](url)

If the image is too big and use the `requestImageForAsset` function will lead to memory leaks.

`requestImageDataForAsset` function will fix this issue. and it default uses the `PHImageManagerMaximumSize` and `PHImageContentModeDefault` compared with the `requestImageForAsset`.

Already tested by Xcode `instrument leaks`.

