### PR TITLE
 add tintColor transition, fix qmui_usedAsTableHeaderView

### DIFF
--- a/QMUIKit/QMUIComponents/NavigationBarTransition/UINavigationController+NavigationBarTransition.m
+++ b/QMUIKit/QMUIComponents/NavigationBarTransition/UINavigationController+NavigationBarTransition.m
@@ -288,7 +288,15 @@
         // 导航栏上控件的主题色
         if ([vc respondsToSelector:@selector(navigationBarTintColor)]) {
             UIColor *tintColor = [vc navigationBarTintColor];
-            viewController.navigationController.navigationBar.tintColor = tintColor;
+            // 手势从 B 返回 A 过程中，取消手势，会调用 B 的 viewWillAppear，animateAlongsideTransition 在这种情况下不会生效，所以要用 qmui_poppingByInteractivePopGestureRecognizer 针对这种情况判断。
+            BOOL shouldApplyTintColorTransition = (animated && ![vc qmui_poppingByInteractivePopGestureRecognizer]);
+            if (shouldApplyTintColorTransition) {
+                [viewController.transitionCoordinator animateAlongsideTransition:^ (id <UIViewControllerTransitionCoordinatorContext> context) {
+                    viewController.navigationController.navigationBar.tintColor = tintColor;
+                } completion:nil];
+            } else {
+                viewController.navigationController.navigationBar.tintColor = tintColor;
+            }
         } else if (QMUICMIActivated) {
             viewController.navigationController.navigationBar.tintColor = NavBarTintColor;
         }

--- a/QMUIKit/QMUIComponents/NavigationBarTransition/UINavigationController+NavigationBarTransition.m
+++ b/QMUIKit/QMUIComponents/NavigationBarTransition/UINavigationController+NavigationBarTransition.m
@@ -286,8 +286,10 @@
         }
         
         // 导航栏上控件的主题色
-        if ([vc respondsToSelector:@selector(navigationBarTintColor)]) {
-            UIColor *tintColor = [vc navigationBarTintColor];
+        UIColor *tintColor =
+        [vc respondsToSelector:@selector(navigationBarTintColor)] ? [vc navigationBarTintColor] :
+                                                 QMUICMIActivated ? NavBarTintColor : nil;
+        if (tintColor) {
             // 手势从 B 返回 A 过程中，取消手势，会调用 B 的 viewWillAppear，animateAlongsideTransition 在这种情况下不会生效，所以要用 qmui_poppingByInteractivePopGestureRecognizer 针对这种情况判断。
             BOOL shouldApplyTintColorTransition = (animated && ![vc qmui_poppingByInteractivePopGestureRecognizer]);
             if (shouldApplyTintColorTransition) {
@@ -297,8 +299,6 @@
             } else {
                 viewController.navigationController.navigationBar.tintColor = tintColor;
             }
-        } else if (QMUICMIActivated) {
-            viewController.navigationController.navigationBar.tintColor = NavBarTintColor;
         }
         
         // 导航栏title的颜色


### PR DESCRIPTION
1、给 UINavigationController 添加 tintColor 转场过渡支持
2、完善 qmui_usedAsTableHeaderView 的修复，解决系统布局错误，导致 UISearchBar 从激活状态取消回到原来的位置时出现抖动