### PR TITLE
QMUIHelper 判断屏幕尺寸兼容 iPhone 11、增加 deviceName 返回设备实际型号

### DIFF
--- a/QMUIKit/QMUICore/QMUIHelper.h
+++ b/QMUIKit/QMUICore/QMUIHelper.h
@@ -144,13 +144,13 @@ extern NSString *const _Nonnull QMUIResourcesMainBundleName;
 /// 将屏幕分为普通和紧凑两种，这个方法用于判断普通屏幕
 + (BOOL)isRegularScreen;
 
-/// iPhone XS Max
+/// iPhone XS Max / 11 Pro Max
 + (BOOL)is65InchScreen;
 
-/// iPhone XR
+/// iPhone XR / 11
 + (BOOL)is61InchScreen;
 
-/// iPhone X/XS
+/// iPhone X / XS / 11Pro
 + (BOOL)is58InchScreen;
 
 /// iPhone 8 Plus

--- a/QMUIKit/QMUICore/QMUIHelper.h
+++ b/QMUIKit/QMUICore/QMUIHelper.h
@@ -131,7 +131,10 @@ extern NSString *const _Nonnull QMUIResourcesMainBundleName;
 
 @interface QMUIHelper (Device)
 
+/// 如 iPhone12,5、iPad6,8
 + (nonnull NSString *)deviceModel;
+/// 如 iPhone 11 Pro Max、iPad Pro (12.9 inch)
++ (nonnull NSString *)deviceName;
 
 + (BOOL)isIPad;
 + (BOOL)isIPod;

--- a/QMUIKit/QMUICore/QMUIHelper.m
+++ b/QMUIKit/QMUICore/QMUIHelper.m
@@ -376,7 +376,8 @@ static NSInteger is65InchScreen = -1;
     if (is65InchScreen < 0) {
         // Since iPhone XS Max and iPhone XR share the same resolution, we have to distinguish them using the model identifiers
         // 由于 iPhone XS Max 和 iPhone XR 的屏幕宽高是一致的，我们通过机器 Identifier 加以区别
-        is65InchScreen = (DEVICE_WIDTH == self.screenSizeFor65Inch.width && DEVICE_HEIGHT == self.screenSizeFor65Inch.height && ([[QMUIHelper deviceModel] isEqualToString:@"iPhone11,4"] || [[QMUIHelper deviceModel] isEqualToString:@"iPhone11,6"])) ? 1 : 0;
+        // 数据来源：https://www.theiphonewiki.com/wiki/Models
+        is65InchScreen = (DEVICE_WIDTH == self.screenSizeFor65Inch.width && DEVICE_HEIGHT == self.screenSizeFor65Inch.height && ([[QMUIHelper deviceModel] isEqualToString:@"iPhone11,4"] || [[QMUIHelper deviceModel] isEqualToString:@"iPhone11,6"] && [[QMUIHelper deviceModel] isEqualToString:@"iPhone12,5"])) ? 1 : 0;
     }
     return is65InchScreen > 0;
 }
@@ -384,7 +385,7 @@ static NSInteger is65InchScreen = -1;
 static NSInteger is61InchScreen = -1;
 + (BOOL)is61InchScreen {
     if (is61InchScreen < 0) {
-        is61InchScreen = (DEVICE_WIDTH == self.screenSizeFor61Inch.width && DEVICE_HEIGHT == self.screenSizeFor61Inch.height && [[QMUIHelper deviceModel] isEqualToString:@"iPhone11,8"]) ? 1 : 0;
+        is61InchScreen = (DEVICE_WIDTH == self.screenSizeFor61Inch.width && DEVICE_HEIGHT == self.screenSizeFor61Inch.height && [[QMUIHelper deviceModel] isEqualToString:@"iPhone11,8"] && [[QMUIHelper deviceModel] isEqualToString:@"iPhone12,1"]) ? 1 : 0;
     }
     return is61InchScreen > 0;
 }

--- a/QMUIKit/QMUICore/QMUIHelper.m
+++ b/QMUIKit/QMUICore/QMUIHelper.m
@@ -294,7 +294,7 @@ static CGFloat pixelOne = -1.0f;
     static NSString *name;
     dispatch_once(&onceToken, ^{
         NSString *model = [self deviceModel];
-        if (!model) return @"UnKnown Device";
+        if (!model) return @"Unknown Device";
         NSDictionary *dic = @{
             // See https://www.theiphonewiki.com/wiki/Models
             @"iPhone1,1" : @"iPhone 1G",

--- a/QMUIKit/QMUICore/QMUIHelper.m
+++ b/QMUIKit/QMUICore/QMUIHelper.m
@@ -294,7 +294,7 @@ static CGFloat pixelOne = -1.0f;
     static NSString *name;
     dispatch_once(&onceToken, ^{
         NSString *model = [self deviceModel];
-        if (!model) return @"UnKnow Device";
+        if (!model) return @"UnKnown Device";
         NSDictionary *dic = @{
             // See https://www.theiphonewiki.com/wiki/Models
             @"iPhone1,1" : @"iPhone 1G",

--- a/QMUIKit/QMUICore/QMUIHelper.m
+++ b/QMUIKit/QMUICore/QMUIHelper.m
@@ -377,7 +377,7 @@ static NSInteger is65InchScreen = -1;
         // Since iPhone XS Max and iPhone XR share the same resolution, we have to distinguish them using the model identifiers
         // 由于 iPhone XS Max 和 iPhone XR 的屏幕宽高是一致的，我们通过机器 Identifier 加以区别
         // 数据来源：https://www.theiphonewiki.com/wiki/Models
-        is65InchScreen = (DEVICE_WIDTH == self.screenSizeFor65Inch.width && DEVICE_HEIGHT == self.screenSizeFor65Inch.height && ([[QMUIHelper deviceModel] isEqualToString:@"iPhone11,4"] || [[QMUIHelper deviceModel] isEqualToString:@"iPhone11,6"] && [[QMUIHelper deviceModel] isEqualToString:@"iPhone12,5"])) ? 1 : 0;
+        is65InchScreen = (DEVICE_WIDTH == self.screenSizeFor65Inch.width && DEVICE_HEIGHT == self.screenSizeFor65Inch.height && ([[QMUIHelper deviceModel] isEqualToString:@"iPhone11,4"] || [[QMUIHelper deviceModel] isEqualToString:@"iPhone11,6"] || [[QMUIHelper deviceModel] isEqualToString:@"iPhone12,5"])) ? 1 : 0;
     }
     return is65InchScreen > 0;
 }
@@ -385,7 +385,7 @@ static NSInteger is65InchScreen = -1;
 static NSInteger is61InchScreen = -1;
 + (BOOL)is61InchScreen {
     if (is61InchScreen < 0) {
-        is61InchScreen = (DEVICE_WIDTH == self.screenSizeFor61Inch.width && DEVICE_HEIGHT == self.screenSizeFor61Inch.height && [[QMUIHelper deviceModel] isEqualToString:@"iPhone11,8"] && [[QMUIHelper deviceModel] isEqualToString:@"iPhone12,1"]) ? 1 : 0;
+        is61InchScreen = (DEVICE_WIDTH == self.screenSizeFor61Inch.width && DEVICE_HEIGHT == self.screenSizeFor61Inch.height && [[QMUIHelper deviceModel] isEqualToString:@"iPhone11,8"] || [[QMUIHelper deviceModel] isEqualToString:@"iPhone12,1"]) ? 1 : 0;
     }
     return is61InchScreen > 0;
 }

--- a/QMUIKit/QMUICore/QMUIHelper.m
+++ b/QMUIKit/QMUICore/QMUIHelper.m
@@ -289,6 +289,147 @@ static CGFloat pixelOne = -1.0f;
     return [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
 }
 
+- (NSString *)deviceName {
+    static dispatch_once_t onceToken;
+    static NSString *name;
+    dispatch_once(&onceToken, ^{
+        NSString *model = [self deviceModel];
+        if (!model) return @"UnKnow Device";
+        NSDictionary *dic = @{
+            // See https://www.theiphonewiki.com/wiki/Models
+            @"iPhone1,1" : @"iPhone 1G",
+            @"iPhone1,2" : @"iPhone 3G",
+            @"iPhone2,1" : @"iPhone 3GS",
+            @"iPhone3,1" : @"iPhone 4 (GSM)",
+            @"iPhone3,2" : @"iPhone 4",
+            @"iPhone3,3" : @"iPhone 4 (CDMA)",
+            @"iPhone4,1" : @"iPhone 4S",
+            @"iPhone5,1" : @"iPhone 5",
+            @"iPhone5,2" : @"iPhone 5",
+            @"iPhone5,3" : @"iPhone 5c",
+            @"iPhone5,4" : @"iPhone 5c",
+            @"iPhone6,1" : @"iPhone 5s",
+            @"iPhone6,2" : @"iPhone 5s",
+            @"iPhone7,1" : @"iPhone 6 Plus",
+            @"iPhone7,2" : @"iPhone 6",
+            @"iPhone8,1" : @"iPhone 6s",
+            @"iPhone8,2" : @"iPhone 6s Plus",
+            @"iPhone8,4" : @"iPhone SE",
+            @"iPhone9,1" : @"iPhone 7",
+            @"iPhone9,2" : @"iPhone 7 Plus",
+            @"iPhone9,3" : @"iPhone 7",
+            @"iPhone9,4" : @"iPhone 7 Plus",
+            @"iPhone10,1" : @"iPhone 8",
+            @"iPhone10,2" : @"iPhone 8 Plus",
+            @"iPhone10,3" : @"iPhone X",
+            @"iPhone10,4" : @"iPhone 8",
+            @"iPhone10,5" : @"iPhone 8 Plus",
+            @"iPhone10,6" : @"iPhone X",
+            @"iPhone11,2" : @"iPhone XS",
+            @"iPhone11,4" : @"iPhone XS Max",
+            @"iPhone11,6" : @"iPhone XS Max CN",
+            @"iPhone11,8" : @"iPhone XR",
+            @"iPhone12,1" : @"iPhone 11",
+            @"iPhone12,3" : @"iPhone 11 Pro",
+            @"iPhone12,5" : @"iPhone 11 Pro Max",
+
+            @"iPad1,1" : @"iPad 1",
+            @"iPad2,1" : @"iPad 2 (WiFi)",
+            @"iPad2,2" : @"iPad 2 (GSM)",
+            @"iPad2,3" : @"iPad 2 (CDMA)",
+            @"iPad2,4" : @"iPad 2",
+            @"iPad2,5" : @"iPad mini 1",
+            @"iPad2,6" : @"iPad mini 1",
+            @"iPad2,7" : @"iPad mini 1",
+            @"iPad3,1" : @"iPad 3 (WiFi)",
+            @"iPad3,2" : @"iPad 3 (4G)",
+            @"iPad3,3" : @"iPad 3 (4G)",
+            @"iPad3,4" : @"iPad 4",
+            @"iPad3,5" : @"iPad 4",
+            @"iPad3,6" : @"iPad 4",
+            @"iPad4,1" : @"iPad Air",
+            @"iPad4,2" : @"iPad Air",
+            @"iPad4,3" : @"iPad Air",
+            @"iPad4,4" : @"iPad mini 2",
+            @"iPad4,5" : @"iPad mini 2",
+            @"iPad4,6" : @"iPad mini 2",
+            @"iPad4,7" : @"iPad mini 3",
+            @"iPad4,8" : @"iPad mini 3",
+            @"iPad4,9" : @"iPad mini 3",
+            @"iPad5,1" : @"iPad mini 4",
+            @"iPad5,2" : @"iPad mini 4",
+            @"iPad5,3" : @"iPad Air 2",
+            @"iPad5,4" : @"iPad Air 2",
+            @"iPad6,3" : @"iPad Pro (9.7 inch)",
+            @"iPad6,4" : @"iPad Pro (9.7 inch)",
+            @"iPad6,7" : @"iPad Pro (12.9 inch)",
+            @"iPad6,8" : @"iPad Pro (12.9 inch)",
+            @"iPad6,11": @"iPad 5 (WiFi)",
+            @"iPad6,12": @"iPad 5 (WiFi / Cellular)",
+            @"iPad7,1" : @"iPad Pro (12.9 inch, 2nd generation)",
+            @"iPad7,2" : @"iPad Pro (12.9 inch, 2nd generation)",
+            @"iPad7,3" : @"iPad Pro (10.5 inch)",
+            @"iPad7,4" : @"iPad Pro (10.5 inch)",
+            @"iPad7,5" : @"iPad 6",
+            @"iPad7,6" : @"iPad 6",
+            @"iPad8,1" : @"iPad Pro (11 inch)",
+            @"iPad8,2" : @"iPad Pro (11 inch)",
+            @"iPad8,3" : @"iPad Pro (11 inch)",
+            @"iPad8,4" : @"iPad Pro (11 inch)",
+            @"iPad8,5" : @"iPad Pro (12.9 inch, 3rd generation)",
+            @"iPad8,6" : @"iPad Pro (12.9 inch, 3rd generation)",
+            @"iPad8,7" : @"iPad Pro (12.9 inch, 3rd generation)",
+            @"iPad8,8" : @"iPad Pro (12.9 inch, 3rd generation)",
+            @"iPad11,1" : @"iPad mini (5th generation)",
+            @"iPad11,2" : @"iPad mini (5th generation)",
+            @"iPad11,3" : @"iPad Air (3rd generation)",
+            @"iPad11,4" : @"iPad Air (3rd generation)",
+            
+            @"iPod1,1" : @"iPod touch 1",
+            @"iPod2,1" : @"iPod touch 2",
+            @"iPod3,1" : @"iPod touch 3",
+            @"iPod4,1" : @"iPod touch 4",
+            @"iPod5,1" : @"iPod touch 5",
+            @"iPod7,1" : @"iPod touch 6",
+            @"iPod9,1" : @"iPod touch 7",
+            
+            @"i386" : @"Simulator x86",
+            @"x86_64" : @"Simulator x64",
+            
+            @"Watch1,1" : @"Apple Watch (1st generation) 38mm",
+            @"Watch1,2" : @"Apple Watch (1st generation) 42mm",
+            @"Watch2,3" : @"Apple Watch Series 2 38mm",
+            @"Watch2,4" : @"Apple Watch Series 2 42mm",
+            @"Watch2,6" : @"Apple Watch Series 1 38mm",
+            @"Watch2,7" : @"Apple Watch Series 1 42mm",
+            @"Watch3,1" : @"Apple Watch Series 3 38mm",
+            @"Watch3,2" : @"Apple Watch Series 3 42mm",
+            @"Watch3,3" : @"Apple Watch Series 3 38mm",
+            @"Watch3,4" : @"Apple Watch Series 3 42mm",
+            @"Watch4,1" : @"Apple Watch Series 4 40mm",
+            @"Watch4,2" : @"Apple Watch Series 4 44mm",
+            @"Watch4,3" : @"Apple Watch Series 4 40mm",
+            @"Watch4,4" : @"Apple Watch Series 4 44mm",
+            
+            @"AudioAccessory1,1" : @"HomePod",
+            @"AudioAccessory1,2" : @"HomePod",
+            
+            @"AirPods1,1" : @"AirPods (1st generation)",
+            @"AirPods2,1" : @"AirPods (2nd generation)",
+
+            @"AppleTV2,1" : @"Apple TV 2",
+            @"AppleTV3,1" : @"Apple TV 3",
+            @"AppleTV3,2" : @"Apple TV 3",
+            @"AppleTV5,3" : @"Apple TV 4",
+            @"AppleTV6,2" : @"Apple TV 4K",
+        };
+        name = dic[model];
+        if (!name) name = model;
+        if (IS_SIMULATOR) name = [name stringByAppendingString:@" Simulator"];
+    });
+    return name;
+}
+
 static NSInteger isIPad = -1;
 + (BOOL)isIPad {
     if (isIPad < 0) {
@@ -374,9 +515,8 @@ static NSInteger isNotchedScreen = -1;
 static NSInteger is65InchScreen = -1;
 + (BOOL)is65InchScreen {
     if (is65InchScreen < 0) {
-        // Since iPhone XS Max and iPhone XR share the same resolution, we have to distinguish them using the model identifiers
-        // 由于 iPhone XS Max 和 iPhone XR 的屏幕宽高是一致的，我们通过机器 Identifier 加以区别
-        // 数据来源：https://www.theiphonewiki.com/wiki/Models
+        // Since iPhone XS Max、iPhone 11 Pro Max and iPhone XR share the same resolution, we have to distinguish them using the model identifiers
+        // 由于 iPhone XS Max、iPhone 11 Pro Max 这两款机型和 iPhone XR 的屏幕宽高是一致的，我们通过机器 Identifier 加以区别
         is65InchScreen = (DEVICE_WIDTH == self.screenSizeFor65Inch.width && DEVICE_HEIGHT == self.screenSizeFor65Inch.height && ([[QMUIHelper deviceModel] isEqualToString:@"iPhone11,4"] || [[QMUIHelper deviceModel] isEqualToString:@"iPhone11,6"] || [[QMUIHelper deviceModel] isEqualToString:@"iPhone12,5"])) ? 1 : 0;
     }
     return is65InchScreen > 0;


### PR DESCRIPTION
之前用的数据来源是来自于 https://www.theiphonewiki.com/wiki/Models，但目前仍没更新 iPhone11，故暂时用 https://github.com/InderKumarRathore/DeviceUtil/blob/41ec24174856b032bc250de302fcec0578c28801/Source/DeviceUtil%2BConstant.m 里的数据