### PR TITLE
修复了QMUIFloatLayoutView 第一行 item y坐标计算考虑itemMargins.top的问题

### DIFF
--- a/QMUIKit/QMUIComponents/QMUIFloatLayoutView.h
+++ b/QMUIKit/QMUIComponents/QMUIFloatLayoutView.h
@@ -43,7 +43,7 @@ extern const CGSize QMUIFloatLayoutViewAutomaticalMaximumItemSize;
 /**
  *  item 之间的间距，默认为 UIEdgeInsetsZero。
  * 
- *  @warning 上、下、左、右四个边缘的 item 布局时不会考虑 itemMargins.left/bottom/left/right。
+ *  @warning 上、下、左、右四个边缘的 item 布局时不会考虑 itemMargins.left/bottom/top/right。
  */
 @property(nonatomic, assign) UIEdgeInsets itemMargins;
 @end

--- a/QMUIKit/QMUIComponents/QMUIFloatLayoutView.h
+++ b/QMUIKit/QMUIComponents/QMUIFloatLayoutView.h
@@ -43,7 +43,7 @@ extern const CGSize QMUIFloatLayoutViewAutomaticalMaximumItemSize;
 /**
  *  item 之间的间距，默认为 UIEdgeInsetsZero。
  * 
- *  @warning 上、下、左、右四个边缘的 item 布局时不会考虑 itemMargins.left/bottom/top/right。
+ *  @warning 上、下、左、右四个边缘的 item 布局时不会考虑 itemMargins.top/bottom/left/right。
  */
 @property(nonatomic, assign) UIEdgeInsets itemMargins;
 @end

--- a/QMUIKit/QMUIComponents/QMUIFloatLayoutView.m
+++ b/QMUIKit/QMUIComponents/QMUIFloatLayoutView.m
@@ -78,7 +78,8 @@ const CGSize QMUIFloatLayoutViewAutomaticalMaximumItemSize = {-1, -1};
         if (shouldBreakline) {
             // 换行，每一行第一个 item 是不考虑 itemMargins 的
             if (shouldLayout) {
-                itemView.frame = CGRectMake(ValueSwitchAlignLeftOrRight(self.padding.left, size.width - self.padding.right - itemViewSize.width), currentRowMaxY + self.itemMargins.top, itemViewSize.width, itemViewSize.height);
+                /** 修改原因: 原代码会在第一行的 item 的 y 值计算中考虑 itemMargins.top */
+                itemView.frame = CGRectMake(ValueSwitchAlignLeftOrRight(self.padding.left, size.width - self.padding.right - itemViewSize.width), currentRowMaxY, itemViewSize.width, itemViewSize.height);
             }
             
             itemViewOrigin.x = ValueSwitchAlignLeftOrRight(self.padding.left + itemViewSize.width + self.itemMargins.right, size.width - self.padding.right - itemViewSize.width - self.itemMargins.left);
@@ -86,7 +87,8 @@ const CGSize QMUIFloatLayoutViewAutomaticalMaximumItemSize = {-1, -1};
         } else {
             // 当前行放得下
             if (shouldLayout) {
-                itemView.frame = CGRectMake(ValueSwitchAlignLeftOrRight(itemViewOrigin.x + self.itemMargins.left, itemViewOrigin.x - self.itemMargins.right - itemViewSize.width), itemViewOrigin.y + self.itemMargins.top, itemViewSize.width, itemViewSize.height);
+                /** 修改原因: 原代码会在第一行的 item 的 y 值计算中考虑 itemMargins.top */
+                itemView.frame = CGRectMake(ValueSwitchAlignLeftOrRight(itemViewOrigin.x + self.itemMargins.left, itemViewOrigin.x - self.itemMargins.right - itemViewSize.width), itemViewOrigin.y, itemViewSize.width, itemViewSize.height);
             }
             
             itemViewOrigin.x = ValueSwitchAlignLeftOrRight(itemViewOrigin.x + UIEdgeInsetsGetHorizontalValue(self.itemMargins) + itemViewSize.width,

--- a/QMUIKit/QMUIComponents/QMUIFloatLayoutView.m
+++ b/QMUIKit/QMUIComponents/QMUIFloatLayoutView.m
@@ -64,38 +64,33 @@ const CGSize QMUIFloatLayoutViewAutomaticalMaximumItemSize = {-1, -1};
     CGFloat currentRowMaxY = itemViewOrigin.y;
     CGSize maximumItemSize = CGSizeEqualToSize(self.maximumItemSize, QMUIFloatLayoutViewAutomaticalMaximumItemSize) ? CGSizeMake(size.width - UIEdgeInsetsGetHorizontalValue(self.padding), size.height - UIEdgeInsetsGetVerticalValue(self.padding)) : self.maximumItemSize;
     
-    for (NSInteger i = 0, l = visibleItemViews.count; i < l; i ++) {
+    for (NSInteger i = 0, l = visibleItemViews.count; i < l; i++) {
         UIView *itemView = visibleItemViews[i];
         
+        CGRect itemViewFrame;
         CGSize itemViewSize = [itemView sizeThatFits:maximumItemSize];
-        itemViewSize.width = fmax(self.minimumItemSize.width, itemViewSize.width);
-        itemViewSize.height = fmax(self.minimumItemSize.height, itemViewSize.height);
-        itemViewSize.width = fmin(maximumItemSize.width, itemViewSize.width);
-        itemViewSize.height = fmin(maximumItemSize.height, itemViewSize.height);
+        itemViewSize.width = MIN(maximumItemSize.width, MAX(self.minimumItemSize.width, itemViewSize.width));
+        itemViewSize.height = MIN(maximumItemSize.height, MAX(self.minimumItemSize.height, itemViewSize.height));
         
+        NSInteger line = -1;
         BOOL shouldBreakline = i == 0 ? YES : ValueSwitchAlignLeftOrRight(itemViewOrigin.x + self.itemMargins.left + itemViewSize.width + self.padding.right > size.width,
                                                            itemViewOrigin.x - self.itemMargins.right - itemViewSize.width - self.padding.left < 0);
         if (shouldBreakline) {
+            line++;
+            currentRowMaxY += line > 0 ? self.itemMargins.top : 0;
             // 换行，每一行第一个 item 是不考虑 itemMargins 的
-            if (shouldLayout) {
-                /** 修改原因: 原代码会在第一行的 item 的 y 值计算中考虑 itemMargins.top */
-                itemView.frame = CGRectMake(ValueSwitchAlignLeftOrRight(self.padding.left, size.width - self.padding.right - itemViewSize.width), currentRowMaxY, itemViewSize.width, itemViewSize.height);
-            }
-            
-            itemViewOrigin.x = ValueSwitchAlignLeftOrRight(self.padding.left + itemViewSize.width + self.itemMargins.right, size.width - self.padding.right - itemViewSize.width - self.itemMargins.left);
-            itemViewOrigin.y = currentRowMaxY;
+            itemViewFrame = CGRectMake(ValueSwitchAlignLeftOrRight(self.padding.left, size.width - self.padding.right - itemViewSize.width), currentRowMaxY, itemViewSize.width, itemViewSize.height);
+            itemViewOrigin.y = CGRectGetMinY(itemViewFrame);
         } else {
             // 当前行放得下
-            if (shouldLayout) {
-                /** 修改原因: 原代码会在第一行的 item 的 y 值计算中考虑 itemMargins.top */
-                itemView.frame = CGRectMake(ValueSwitchAlignLeftOrRight(itemViewOrigin.x + self.itemMargins.left, itemViewOrigin.x - self.itemMargins.right - itemViewSize.width), itemViewOrigin.y, itemViewSize.width, itemViewSize.height);
-            }
-            
-            itemViewOrigin.x = ValueSwitchAlignLeftOrRight(itemViewOrigin.x + UIEdgeInsetsGetHorizontalValue(self.itemMargins) + itemViewSize.width,
-                                                           itemViewOrigin.x - itemViewSize.width - UIEdgeInsetsGetHorizontalValue(self.itemMargins));
+            itemViewFrame = CGRectMake(ValueSwitchAlignLeftOrRight(itemViewOrigin.x + self.itemMargins.left, itemViewOrigin.x - self.itemMargins.right - itemViewSize.width), itemViewOrigin.y, itemViewSize.width, itemViewSize.height);
         }
+        itemViewOrigin.x = ValueSwitchAlignLeftOrRight(CGRectGetMaxX(itemViewFrame) + self.itemMargins.right, CGRectGetMinX(itemViewFrame) - self.itemMargins.left);
+        currentRowMaxY = MAX(currentRowMaxY, CGRectGetMaxY(itemViewFrame) + self.itemMargins.bottom);
         
-        currentRowMaxY = fmax(currentRowMaxY, itemViewOrigin.y + UIEdgeInsetsGetVerticalValue(self.itemMargins) + itemViewSize.height);
+        if (shouldLayout) {
+            itemView.frame = itemViewFrame;
+        }
     }
     
     // 最后一行不需要考虑 itemMarins.bottom，所以这里减掉


### PR DESCRIPTION
发现过程:
    在阅读qmuidemo源码时发现,修改QDFloatLayoutViewController.m中22行
        self.floatLayoutView.itemMargins = UIEdgeInsetsMake(0, 0, 10, 10);
    为:
        self.floatLayoutView.itemMargins = UIEdgeInsetsMake(10, 10, 10, 10);
    之后,显示的第一个item的y值应为12,但实际显示为22.不符合代码注释所描述

修改以后,再进行验证,问题解决,特提交一个PR
