### PR TITLE
[fix][无障碍]修复在旁白开启状态下cell的defaultAccessoryButton无朗读的问题

### DIFF
--- a/QMUIKit/QMUIComponents/QMUITableViewCell.m
+++ b/QMUIKit/QMUIComponents/QMUITableViewCell.m
@@ -176,6 +176,7 @@
     if (!self.defaultAccessoryButton) {
         self.defaultAccessoryButton = [[QMUIButton alloc] init];
         [self.defaultAccessoryButton addTarget:self action:@selector(handleAccessoryButtonEvent:) forControlEvents:UIControlEventTouchUpInside];
+        self.defaultAccessoryButton.accessibilityLabel = @"更多信息";
     }
 }
 


### PR DESCRIPTION
在旁白开启的状态下，触摸defaultAccessoryButton只会提示按钮，会导致依赖旁白操控手机的障碍用户无法理解和使用。遵循系统AccessoryDetailButton在中文语言下的朗读，将defaultAccessoryButton的AccessibilityLabel设置为“更多信息”。