### PR TITLE
[fix][无障碍]修复在旁白开启状态下HeaderFooterView中的accessoryView无法被访问的问题

### DIFF
--- a/QMUIKit/QMUIComponents/QMUITableViewHeaderFooterView.m
+++ b/QMUIKit/QMUIComponents/QMUITableViewHeaderFooterView.m
@@ -92,6 +92,8 @@
         [_accessoryView removeFromSuperview];
     }
     _accessoryView = accessoryView;
+    self.isAccessibilityElement = NO;
+    self.titleLabel.accessibilityTraits |= UIAccessibilityTraitHeader;
     [self.contentView addSubview:accessoryView];
 }
 


### PR DESCRIPTION
设置了accessoryView的TableViewHeaderFooterView，在旁白开启的状态下，是无法访问accessoryView的，参考下边的截图。
<img width="408" alt="Screen Shot 2020-06-30 at 11 14 19 AM" src="https://user-images.githubusercontent.com/47623399/86079506-3cd1e880-bac3-11ea-8c24-eb1446a48779.png">
这会导致依赖旁白操控手机的障碍用户无法获取和操控accessoryView。对设置accessoryView的TableViewHeaderFooterView，将TableViewHeaderFooterView拆分为titleLabel和accessoryView两个区域，同时为titleLabel添加标题的朗读提示，截图为修复后的效果。
<img width="408" alt="Screen Shot 2020-06-30 at 11 16 09 AM" src="https://user-images.githubusercontent.com/47623399/86079520-452a2380-bac3-11ea-988c-4a3f735bbdcc.png">

<img width="408" alt="Screen Shot 2020-06-30 at 11 18 25 AM" src="https://user-images.githubusercontent.com/47623399/86079605-7145a480-bac3-11ea-8a24-7e1f13ca6b97.png">



