### PR TITLE
[fix][无障碍]修复在旁白开启状态下NavigationTitleView中的titleLabel无标题提示的问题

### DIFF
--- a/QMUIKit/QMUIComponents/QMUINavigationTitleView.m
+++ b/QMUIKit/QMUIComponents/QMUINavigationTitleView.m
@@ -102,11 +102,13 @@
         _titleLabel = [[UILabel alloc] init];
         self.titleLabel.textAlignment = NSTextAlignmentCenter;
         self.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
+        self.titleLabel.accessibilityTraits |= UIAccessibilityTraitHeader;
         [self.contentView addSubview:self.titleLabel];
         
         _subtitleLabel = [[UILabel alloc] init];
         self.subtitleLabel.textAlignment = NSTextAlignmentCenter;
         self.subtitleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
+        self.subtitleLabel.accessibilityTraits |= UIAccessibilityTraitHeader;
         [self.contentView addSubview:self.subtitleLabel];
         
         self.userInteractionEnabled = NO;


### PR DESCRIPTION
在旁白开启的状态下，触摸NavigationTitleView的titleLabel, subtitleLabel不会有标题的提示，这会影响依赖旁白操控手机的障碍用户对界面的理解。参考系统的NavigationBar的效果，为titleLabel, subtitleLabel添加标题的朗读提示。