### PR TITLE
使用系统字符串方法去比对版本号

### DIFF
--- a/QMUIKit/QMUICore/QMUIHelper.m
+++ b/QMUIKit/QMUICore/QMUIHelper.m
@@ -711,24 +711,7 @@ static NSInteger isHighPerformanceDevice = -1;
 }
 
 + (NSComparisonResult)compareSystemVersion:(NSString *)currentVersion toVersion:(NSString *)targetVersion {
-    NSArray *currentVersionArr = [currentVersion componentsSeparatedByString:@"."];
-    NSArray *targetVersionArr = [targetVersion componentsSeparatedByString:@"."];
-    
-    NSInteger pos = 0;
-    
-    while ([currentVersionArr count] > pos || [targetVersionArr count] > pos) {
-        NSInteger v1 = [currentVersionArr count] > pos ? [[currentVersionArr objectAtIndex:pos] integerValue] : 0;
-        NSInteger v2 = [targetVersionArr count] > pos ? [[targetVersionArr objectAtIndex:pos] integerValue] : 0;
-        if (v1 < v2) {
-            return NSOrderedDescending;
-        }
-        else if (v1 > v2) {
-            return NSOrderedAscending;
-        }
-        pos++;
-    }
-    
-    return NSOrderedSame;
+    return [currentVersion compare:targetVersion options:NSNumericSearch];
 }
 
 + (BOOL)isCurrentSystemAtLeastVersion:(NSString *)targetVersion {


### PR DESCRIPTION
使用系统的 `compare` 方法省去自己手动拆分比对
建议： `+[QMUIHelper compareSystemVersion:toVersion:]` 方法不需要局限于判断 OS 的版本，也可以比对 APP 的版本 QMUIHelper (Version)