### PR TITLE
当设置tabBarStyle == UIBarStyleBlack 且 _tabBarBackgroundImage 不为空是后，设置se…

### DIFF
--- a/QMUIKit/QMUICore/QMUIConfiguration.m
+++ b/QMUIKit/QMUICore/QMUIConfiguration.m
@@ -557,7 +557,11 @@ static BOOL QMUI_hasAppliedInitialTemplate;
 - (void)setTabBarStyle:(UIBarStyle)tabBarStyle {
     _tabBarStyle = tabBarStyle;
     if (@available(iOS 13.0, *)) {
-        self.tabBarAppearance.backgroundEffect = [UIBlurEffect effectWithStyle:tabBarStyle == UIBarStyleDefault ? UIBlurEffectStyleSystemChromeMaterialLight : UIBlurEffectStyleSystemChromeMaterialDark];
+        if (_tabBarBackgroundImage && tabBarStyle == UIBarStyleBlack) {
+            self.tabBarAppearance.backgroundEffect = nil;
+        } else {
+            self.tabBarAppearance.backgroundEffect = [UIBlurEffect effectWithStyle:tabBarStyle == UIBarStyleDefault ? UIBlurEffectStyleSystemChromeMaterialLight : UIBlurEffectStyleSystemChromeMaterialDark];
+        }
         [self updateTabBarAppearance];
     } else {
         [UITabBar appearance].barStyle = tabBarStyle;


### PR DESCRIPTION
…lf.tabBarAppearance.backgroundEffect = nil;实现tabbar透明显示。这样就可以设置tabbar背景图为不规则图片。