### PR TITLE
兼容未启用CLANG_ENABLE_MODULES pod集成时编译错误

### DIFF
--- a/QMUIKit.podspec
+++ b/QMUIKit.podspec
@@ -22,6 +22,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'QMUICore' do |ss|
     ss.source_files = 'QMUIKit/QMUIKit.h', 'QMUIKit/QMUICore', 'QMUIKit/UIKitExtensions'
+		ss.frameworks = 'CoreImage', 'ImageIO'
     ss.dependency 'QMUIKit/QMUIWeakObjectContainer'
     ss.dependency 'QMUIKit/QMUILog'
   end
@@ -345,6 +346,7 @@ Pod::Spec.new do |s|
 
     ss.subspec 'QMUIZoomImageView' do |sss|
       sss.source_files = 'QMUIKit/QMUIComponents/QMUIZoomImageView.{h,m}'
+			sss.frameworks = 'PhotosUI', 'CoreMedia', 'AVFoundation', 'QuartzCore'
       sss.dependency 'QMUIKit/QMUIResources'
       sss.dependency 'QMUIKit/QMUIComponents/QMUIEmptyView'
 			sss.dependency 'QMUIKit/QMUIComponents/QMUIButton'
@@ -355,7 +357,7 @@ Pod::Spec.new do |s|
 
     ss.subspec 'QMUIAssetLibrary' do |sss|
       sss.source_files = 'QMUIKit/QMUIComponents/AssetLibrary/*.{h,m}'
-      sss.weak_framework = 'Photos'
+      sss.frameworks = 'Photos', 'CoreServices'
     end
 
     ss.subspec 'QMUIImagePickerLibrary' do |sss|

--- a/QMUIKit/QMUIComponents/AssetLibrary/QMUIAsset.m
+++ b/QMUIKit/QMUIComponents/AssetLibrary/QMUIAsset.m
@@ -14,11 +14,12 @@
 //
 
 #import "QMUIAsset.h"
-#import <Photos/Photos.h>
-#import <MobileCoreServices/UTCoreTypes.h>
 #import "QMUICore.h"
 #import "QMUIAssetsManager.h"
 #import "NSString+QMUI.h"
+
+#import <Photos/Photos.h>
+#import <CoreServices/UTCoreTypes.h>
 
 static NSString * const kAssetInfoImageData = @"imageData";
 static NSString * const kAssetInfoOriginInfo = @"originInfo";

--- a/QMUIKit/QMUIComponents/QMUIZoomImageView.m
+++ b/QMUIKit/QMUIComponents/QMUIZoomImageView.m
@@ -22,9 +22,13 @@
 #import "UIScrollView+QMUI.h"
 #import "QMUIButton.h"
 #import "QMUISlider.h"
-#import <MediaPlayer/MediaPlayer.h>
 #import "UILabel+QMUI.h"
 #import "QMUIPieProgressView.h"
+
+#import <QuartzCore/QuartzCore.h>
+#import <CoreMedia/CoreMedia.h>
+#import <AVFoundation/AVFoundation.h>
+#import <MediaPlayer/MediaPlayer.h>
 
 #define kIconsColor UIColorMakeWithRGBA(255, 255, 255, .75)
 

--- a/QMUIKit/UIKitExtensions/UIImage+QMUI.m
+++ b/QMUIKit/UIKitExtensions/UIImage+QMUI.m
@@ -18,6 +18,9 @@
 #import "UIBezierPath+QMUI.h"
 #import "UIColor+QMUI.h"
 #import "QMUILog.h"
+
+#import <ImageIO/ImageIO.h>
+#import <CoreImage/CoreImage.h>
 #import <Accelerate/Accelerate.h>
 
 CG_INLINE CGSize


### PR DESCRIPTION
默认是开启了 CLANG_ENABLE_MODULES 所以当 import某个系统库时,不需要手动在工程添加对应库的依赖
但有些时候需要禁用 CLANG_ENABLE_MODULES, 禁用后就会导致某些组件依赖的系统的不会被自动链接从而导致编译失败