### PR TITLE
修复 QMUITextView 调用 -initWithFrame:textContainer: 时没有初始化一些相关属性（例如 maxi…

### DIFF
--- a/QMUIKit/QMUIComponents/QMUITextView.m
+++ b/QMUIKit/QMUIComponents/QMUITextView.m
@@ -66,6 +66,22 @@ const UIEdgeInsets kSystemTextViewFixTextInsets = {0, 5, 0, 5};
     return self;
 }
 
+- (instancetype)initWithFrame:(CGRect)frame textContainer:(NSTextContainer *)textContainer {
+    self = [super initWithFrame:frame textContainer:textContainer];
+    if (self) {
+        [self didInitialize];
+        if (QMUICMIActivated) {
+            UIColor *textColor = TextFieldTextColor;
+            if (textColor) {
+                self.textColor = textColor;
+            }
+            
+            self.tintColor = TextFieldTintColor;
+        }
+    }
+    return self;
+}
+
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     if (self = [super initWithCoder:aDecoder]) {
         [self didInitialize];


### PR DESCRIPTION
…mumTextLength 为 0），而导致 setText 时，已输入字符串被清空。